### PR TITLE
Correct Pigeon mount pose for counter-clockwise rotation

### DIFF
--- a/src/main/java/com/team9470/TunerConstants.java
+++ b/src/main/java/com/team9470/TunerConstants.java
@@ -73,7 +73,16 @@ public class TunerConstants {
             );
     private static final CANcoderConfiguration encoderInitialConfigs = new CANcoderConfiguration();
     // Configs for the Pigeon 2; leave this null to skip applying Pigeon 2 configs
-    private static final Pigeon2Configuration pigeonConfigs = null;
+    private static final Pigeon2Configuration pigeonConfigs = new Pigeon2Configuration();
+
+    static {
+        /*
+         * The Pigeon 2 is mounted 90 degrees counter-clockwise from the robot-forward
+         * direction, so inform the device of the mount pose to ensure the reported
+         * yaw matches the robot coordinate frame.
+         */
+        pigeonConfigs.MountPose.MountPoseYaw = 90.0;
+    }
     // Every 1 rotation of the azimuth results in kCoupleRatio drive motor turns;
     // This may need to be tuned to your individual robot
     private static final double kCoupleRatio = 5.4;


### PR DESCRIPTION
## Summary
- update the Pigeon 2 mount pose description to reflect a 90° counter-clockwise orientation
- set the mount pose yaw to +90° so gyro readings align with the robot frame

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e331f933c88324a993dacc80098da8