### PR TITLE
Remove redundant Arm hasItem state

### DIFF
--- a/src/main/java/com/team9470/subsystems/Arm.java
+++ b/src/main/java/com/team9470/subsystems/Arm.java
@@ -44,7 +44,6 @@ public class Arm extends SubsystemBase {
 
     // --- State tracking ---
     private boolean rollersRunning = false;
-    private boolean hasItem = false;
     
     // Item type tracking
     private boolean holdingCoral = false;
@@ -80,7 +79,6 @@ public class Arm extends SubsystemBase {
         public Angle goal;
         public HomingState homingState;
         public boolean rollersRunning;
-        public boolean hasItem;
 
         public double setpointPositionRotations;
     }
@@ -114,9 +112,6 @@ public class Arm extends SubsystemBase {
             homingState = HomingState.IDLE;
         }
         periodicIO.homingState = homingState;
-
-        // Item detection and hold logic
-//        updateItemDetection();
 
         writePeriodicOutputs();
 
@@ -162,7 +157,6 @@ public class Arm extends SubsystemBase {
 
         periodicIO.goal = targetAngle;
         periodicIO.rollersRunning = rollersRunning;
-        periodicIO.hasItem = hasItem;
 
         periodicIO.setpointPositionRotations = setpointPositionSignal.asSupplier().get();
     }
@@ -192,24 +186,6 @@ public class Arm extends SubsystemBase {
                 break;
         }
     }
-
-//    /** Update item detection and hold logic */
-//    private void updateItemDetection() {
-//        // Check if rollers are drawing high current (indicating item resistance)
-//        boolean rollerHighCurrent = periodicIO.rollerCurrent.gte(ArmConstants.ITEM_DETECTION_CURRENT);
-//
-//        if (rollerHighCurrent) {
-//            hasItem = true;
-//        } else if (!holdingItem) {
-//            hasItem = false;
-//        }
-//
-//        // If we have an item and rollers are running, switch to hold mode
-//        if (hasItem && rollersRunning && !holdingItem) {
-//            holdingItem = true;
-//            holdItem();
-//        }
-//    }
 
     /** Write outputs to motors */
     private void writePeriodicOutputs() {
@@ -256,7 +232,6 @@ public class Arm extends SubsystemBase {
     public void startIntake() {
         rollerMotor.setVoltage(ArmConstants.ROLLER_INTAKE_SPEED.in(Volts));
         rollersRunning = true;
-        hasItem = false;
     }
 
     /** Start output rollers */
@@ -284,11 +259,6 @@ public class Arm extends SubsystemBase {
         homingStartTime = Seconds.of(Timer.getFPGATimestamp());;
     }
 
-    /** Check if item is detected */
-    public boolean hasItem() {
-        return hasItem;
-    }
-
     /** Check if rollers are running */
     public boolean areRollersRunning() {
         return rollersRunning;
@@ -314,7 +284,6 @@ public class Arm extends SubsystemBase {
     public void clearGamePieceFlags() {
         holdingCoral = false;
         holdingAlgae = false;
-        hasItem = false;
     }
 
     /** Check if holding coral */
@@ -398,7 +367,7 @@ public class Arm extends SubsystemBase {
                     }
                     @Override
                     public boolean isFinished() {
-                        return !hasItem(); // Stop when item is no longer detected
+                        return !isHoldingItem(); // Stop when item is no longer detected
                     }
                     @Override
                     public void end(boolean interrupted) {
@@ -416,7 +385,7 @@ public class Arm extends SubsystemBase {
                     }
                     @Override
                     public boolean isFinished() {
-                        return !hasItem(); // Stop when item is no longer detected
+                        return !isHoldingItem(); // Stop when item is no longer detected
                     }
                     @Override
                     public void end(boolean interrupted) {

--- a/src/main/java/com/team9470/subsystems/Superstructure.java
+++ b/src/main/java/com/team9470/subsystems/Superstructure.java
@@ -238,7 +238,7 @@ public class Superstructure extends SubsystemBase {
                     arm.clearGamePieceFlags();
                 }),
                 new ParallelDeadlineGroup(
-                        Commands.waitUntil(arm::hasItem).withTimeout(ArmConstants.INTAKE_TIMEOUT.in(Seconds)),
+                        Commands.waitUntil(arm::isHoldingItem).withTimeout(ArmConstants.INTAKE_TIMEOUT.in(Seconds)),
                         new ParallelCommandGroup(
                                 elevator.L0(),
                                 arm.moveCommand(ArmConstants.ALGAE_GROUND_INTAKE_ANGLE),
@@ -246,7 +246,7 @@ public class Superstructure extends SubsystemBase {
                         )
                 ),
                 Commands.runOnce(() -> {
-                    if (arm.hasItem()) {
+                    if (arm.isHoldingItem()) {
                         arm.holdItem();
                         arm.setHoldingAlgae(true);
                         pieceState = GamePieceState.ALGAE_IN_ARM;
@@ -278,7 +278,7 @@ public class Superstructure extends SubsystemBase {
                     arm.clearGamePieceFlags();
                 }),
                 new ParallelDeadlineGroup(
-                        Commands.waitUntil(arm::hasItem).withTimeout(ArmConstants.INTAKE_TIMEOUT.in(Seconds)),
+                        Commands.waitUntil(arm::isHoldingItem).withTimeout(ArmConstants.INTAKE_TIMEOUT.in(Seconds)),
                         new ParallelCommandGroup(
                                 elevator.getLevelCommand(level.elevatorLevel()),
                                 arm.moveCommand(ArmConstants.ALGAE_REEF_INTAKE_ANGLE),
@@ -286,7 +286,7 @@ public class Superstructure extends SubsystemBase {
                         )
                 ),
                 Commands.runOnce(() -> {
-                    if (arm.hasItem()) {
+                    if (arm.isHoldingItem()) {
                         arm.holdItem();
                         arm.setHoldingAlgae(true);
                         pieceState = GamePieceState.ALGAE_IN_ARM;


### PR DESCRIPTION
## Summary
- remove the Arm.hasItem state and the unused updateItemDetection logic
- rely on the current-based isHoldingItem helper for algae pickup and scoring commands
- update Superstructure algae pickup flows to finish based on the surviving detection method

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68f4a2fa6930832490fdc063f36edba6