### PR TITLE
Remove redundant superstructure helpers

### DIFF
--- a/src/main/java/com/team9470/commands/AutoScoring.java
+++ b/src/main/java/com/team9470/commands/AutoScoring.java
@@ -45,9 +45,7 @@ public class AutoScoring {
                                 .andThen(superstructure.waitForIntake().asProxy())
                                 .andThen(superstructure.raise(objective.level))
                 );
-        if(objective.level == 1){
-            return driveToScore.andThen(superstructure.scoreSlow().asProxy());
-        } else return driveToScore.andThen(superstructure.score().asProxy());
+        return driveToScore.andThen(superstructure.score().asProxy());
     }
 
     public static Command autoScoreWithTimeout(Superstructure superstructure, CoralObjective objective, Swerve drivetrain) {
@@ -72,9 +70,7 @@ public class AutoScoring {
 
     public Command autoScoreNoDrive(Superstructure superstructure) {
         return new DeferredCommand(() -> {
-            if(coralObjective.level == 1){
-                return superstructure.raise(coralObjective.level).andThen(superstructure.scoreSlow());
-            } else return superstructure.raise(coralObjective.level).andThen(superstructure.score());
+            return superstructure.raise(coralObjective.level).andThen(superstructure.score());
         }, Set.of());
     }
 

--- a/src/main/java/com/team9470/commands/Autos.java
+++ b/src/main/java/com/team9470/commands/Autos.java
@@ -86,7 +86,6 @@ public class Autos extends SubsystemBase{
         routine.active().onTrue(
                 startToC3.resetOdometry().andThen(
                         scoreL4AutoWaitLower(new InstantCommand(), SCORING_DELAY, 7)
-                                .andThen(superstructure.algaeDown())
                 )
 
         );
@@ -104,7 +103,6 @@ public class Autos extends SubsystemBase{
 
         startToC3.done().onTrue(
                 scoreL4WaitLower(new InstantCommand(), SCORING_DELAY)
-                        .andThen(superstructure.algaeDown())
         );
         return routine;
     }
@@ -114,7 +112,7 @@ public class Autos extends SubsystemBase{
 
         routine.active().onTrue(
                 AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(7, 4), swerve)
-                        .andThen(Commands.parallel(superstructure.algaeDown(), elevator.L0()))
+                        .andThen(elevator.L0())
         );
 
         return routine;
@@ -129,8 +127,7 @@ public class Autos extends SubsystemBase{
         routine.active().onTrue(
                 Commands.sequence(
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(9, 4), swerve),
-                        elevator.L0()
-                                .alongWith(superstructure.algaeUp())
+                        Commands.parallel(elevator.L0())
                                 .withDeadline(alignToSourceWait(true)),
 
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(10, 4), swerve),
@@ -142,8 +139,7 @@ public class Autos extends SubsystemBase{
                                 .withDeadline(alignToSourceWait(true)),
 
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(11, 3), swerve),
-                        elevator.L0()
-                                .alongWith(superstructure.algaeDown())
+                        Commands.parallel(elevator.L0())
                                 .withDeadline(alignToSourceWait(true)),
 
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(10, 3), swerve)
@@ -159,8 +155,7 @@ public class Autos extends SubsystemBase{
         routine.active().onTrue(
                 Commands.sequence(
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(4, 4), swerve),
-                        elevator.L0()
-                                .alongWith(superstructure.algaeUp())
+                        Commands.parallel(elevator.L0())
                                 .withDeadline(alignToSourceWait(false)),
 
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(3, 4), swerve),
@@ -172,8 +167,7 @@ public class Autos extends SubsystemBase{
                                 .withDeadline(alignToSourceWait(false)),
 
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(2, 3), swerve),
-                        elevator.L0()
-                                .alongWith(superstructure.algaeDown())
+                        Commands.parallel(elevator.L0())
                                 .withDeadline(alignToSourceWait(false)),
 
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(3, 3), swerve)
@@ -189,11 +183,11 @@ public class Autos extends SubsystemBase{
         routine.active().onTrue(
                 Commands.sequence(
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(9, 4), swerve),
-                        elevator.L0().alongWith(superstructure.algaeUp())
+                        Commands.parallel(elevator.L0())
                                 .withDeadline(alignToSource(true)),
                         new WaitCommand(INTAKE_DELAY),
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(10, 4), swerve),
-                        elevator.L0().alongWith(superstructure.algaeDown())
+                        Commands.parallel(elevator.L0())
                                 .withDeadline(alignToSource(true)),
                         new WaitCommand(INTAKE_DELAY),
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(11, 4), swerve),
@@ -201,7 +195,7 @@ public class Autos extends SubsystemBase{
                                 .withDeadline(alignToSource(true)),
                         new WaitCommand(INTAKE_DELAY),
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(11, 2), swerve),
-                        elevator.L0().alongWith(superstructure.algaeUp())
+                        Commands.parallel(elevator.L0())
                                 .withDeadline(alignToSource(true)),
                         new WaitCommand(INTAKE_DELAY),
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(10, 2), swerve)
@@ -217,11 +211,11 @@ public class Autos extends SubsystemBase{
         routine.active().onTrue(
                 Commands.sequence(
                         AutoScoring.autoScoreStraight(superstructure, new AutoScoring.CoralObjective(4, 4), swerve),
-                        elevator.L0().alongWith(superstructure.algaeUp())
+                        Commands.parallel(elevator.L0())
                                 .withDeadline(alignToSource(false)),
                         new WaitCommand(INTAKE_DELAY),
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(3, 4), swerve),
-                        elevator.L0().alongWith(superstructure.algaeDown())
+                        Commands.parallel(elevator.L0())
                                 .withDeadline(alignToSource(false)),
                         new WaitCommand(INTAKE_DELAY),
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(2, 4), swerve),
@@ -229,7 +223,7 @@ public class Autos extends SubsystemBase{
                                 .withDeadline(alignToSource(false)),
                         new WaitCommand(INTAKE_DELAY),
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(2, 3), swerve),
-                        elevator.L0().alongWith(superstructure.algaeUp())
+                        Commands.parallel(elevator.L0())
                                 .withDeadline(alignToSource(false)),
                         new WaitCommand(INTAKE_DELAY),
                         AutoScoring.autoScoreWithTimeout(superstructure, new AutoScoring.CoralObjective(3, 3), swerve)

--- a/src/main/java/com/team9470/subsystems/Superstructure.java
+++ b/src/main/java/com/team9470/subsystems/Superstructure.java
@@ -121,14 +121,6 @@ public class Superstructure extends SubsystemBase {
         return indexer.reverseCommand();
     }
 
-    public Command algaeUp() {
-        return Commands.none();
-    }
-
-    public Command algaeDown() {
-        return Commands.none();
-    }
-
     public Command raise(int level) {
         return elevator.getLevelCommand(level);
     }
@@ -141,24 +133,8 @@ public class Superstructure extends SubsystemBase {
         return indexer.outputCommand();
     }
 
-    public Command scoreSlow() {
-        return indexer.outputCommand();
-    }
-
-    public Command triggerAlgaeHoming() {
-        return Commands.none();
-    }
-
     public Command waitForIntake() {
         return new WaitUntilCommand(indexer::isCoralInCradle);
-    }
-
-    public Command funnelOut() {
-        return Commands.none();
-    }
-
-    public Command climberAction() {
-        return Commands.none();
     }
 
     public boolean hasGamePiece() {
@@ -179,10 +155,6 @@ public class Superstructure extends SubsystemBase {
 
     public Intake getIntake() {
         return intake;
-    }
-
-    public Command scoreAndFunnel() {
-        return indexer.outputCommand();
     }
 
     public boolean isCoralInCradle() {


### PR DESCRIPTION
## Summary
- remove unused no-op commands from the superstructure
- simplify auto scoring to call the main score command directly
- inline previous algae up/down placeholders inside autonomous routines

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68f4a3258a248324a4f8c6205887bd96