### PR TITLE
Adjust vision camera offsets for new drivetrain width

### DIFF
--- a/src/main/java/com/team9470/Constants.java
+++ b/src/main/java/com/team9470/Constants.java
@@ -26,9 +26,9 @@ public final class Constants {
     }
 
     public static class VisionConstants {
-        public static final Transform3d FRONT_LEFT_CAMERA_OFFSET = new Transform3d(Units.Inches.of(+12.290427), Units.Inches.of(12.710), Units.Inches.of(+8.803138),
+        public static final Transform3d FRONT_LEFT_CAMERA_OFFSET = new Transform3d(Units.Inches.of(+12.290427), Units.Inches.of(10.710), Units.Inches.of(+8.803138),
                 new Rotation3d(0, Math.toRadians(-28.125), Math.toRadians(-45)));
-        public static final Transform3d FRONT_RIGHT_CAMERA_OFFSET = new Transform3d(Units.Inches.of(+12.290427), Units.Inches.of(-12.710), Units.Inches.of(+8.803138),
+        public static final Transform3d FRONT_RIGHT_CAMERA_OFFSET = new Transform3d(Units.Inches.of(+12.290427), Units.Inches.of(-10.710), Units.Inches.of(+8.803138),
                 new Rotation3d(0, Math.toRadians(-28.125), Math.toRadians(45)));
     }
 


### PR DESCRIPTION
## Summary
- update the vision camera lateral offsets to reflect the 28x32 drivetrain spacing

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68f4a2a3ee50832489a114b068c36435