### PR TITLE
Refine indexer coral beam-break debounce

### DIFF
--- a/src/main/java/com/team9470/Constants.java
+++ b/src/main/java/com/team9470/Constants.java
@@ -100,7 +100,7 @@ public final class Constants {
         // Current thresholds for coral detection
         public static final Current CORAL_DETECTION_CURRENT = Amps.of(8.0);
         
-        // Timeout for coral detection debouncing
+        // Timeout for coral detection debouncing (rising-edge filter)
         public static final double CORAL_DETECTION_TIMEOUT = 0.1; // seconds
         
         public static TalonFXConfiguration getMotorConfig() {

--- a/src/main/java/com/team9470/subsystems/Indexer.java
+++ b/src/main/java/com/team9470/subsystems/Indexer.java
@@ -7,13 +7,13 @@ import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.team254.lib.drivers.TalonFXFactory;
 import com.team254.lib.drivers.TalonUtil;
-import com.team254.lib.util.DelayedBoolean;
 import com.team9470.Constants.IndexerConstants;
 import com.team9470.Ports;
 
 import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.wpilibj.DigitalInput;
-import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.math.filter.Debouncer;
+import edu.wpi.first.math.filter.Debouncer.DebounceType;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -30,40 +30,36 @@ public class Indexer extends SubsystemBase {
     
 
     private final DigitalInput coralSensor = new DigitalInput(Ports.CRADLE_BREAK); //beam break
+
+    private final Debouncer coralDebouncer = new Debouncer(
+        IndexerConstants.CORAL_DETECTION_TIMEOUT,
+        DebounceType.kRising
+    );
+
+    private boolean coralInCradle;
     
     /** STATUS SIGNALS for current monitoring */
     private final StatusSignal<Current> motor1CurrentSignal = indexerMotor1.getStatorCurrent();
     private final StatusSignal<Current> motor2CurrentSignal = indexerMotor2.getStatorCurrent();
     
-    /** Delayed boolean for coral detection debouncing */
-    private final DelayedBoolean coralDetected = new DelayedBoolean(
-        Timer.getFPGATimestamp(), 
-        IndexerConstants.CORAL_DETECTION_TIMEOUT, 
-        false
-    );
-    
-    /** State tracking */
-    private boolean isRunning = false;
-    private boolean coralPresent = false;
-
     public Indexer() {
         // Apply motor configurations
         TalonUtil.applyAndCheckConfiguration(indexerMotor1, IndexerConstants.getMotorConfig());
         TalonUtil.applyAndCheckConfiguration(indexerMotor2, IndexerConstants.getMotorConfig());
-        
+
         // Set up status signals for current monitoring
         motor1CurrentSignal.setUpdateFrequency(50, 0.1);
         motor2CurrentSignal.setUpdateFrequency(50, 0.1);
-        
+
+        coralInCradle = readCradleBeamBreak();
+
         // Set default command to stop the indexer
         setDefaultCommand(stopCommand());
     }
 
     @Override
     public void periodic() {
-        // Update delayed boolean for debouncing
-        coralDetected.update(Timer.getFPGATimestamp(), coralPresent);
-
+        coralInCradle = coralDebouncer.calculate(readCradleBeamBreak());
         // Push values to SmartDashboard
         logTelemetry();
     }
@@ -72,6 +68,11 @@ public class Indexer extends SubsystemBase {
         SmartDashboard.putBoolean("Indexer/hasCoral", hasCoral());
         SmartDashboard.putNumber("Indexer/Current1", indexerMotor1.getStatorCurrent().getValueAsDouble());
         SmartDashboard.putNumber("Indexer/Current2", indexerMotor2.getStatorCurrent().getValueAsDouble());
+    }
+
+    private boolean readCradleBeamBreak() {
+        // The sensor returns false when blocked, so invert to represent coral present.
+        return !coralSensor.get();
     }
 
     /**
@@ -111,40 +112,16 @@ public class Indexer extends SubsystemBase {
      * @return true if coral is detected in the indexer
      */
     public boolean hasCoral() {
-        return coralDetected.update(Timer.getFPGATimestamp(), coralPresent);
+        return coralInCradle;
     }
-
-    /**
-     * Raw beam break state for the cradle. True when a coral is blocking the sensor.
-     */
-    public boolean isCoralInCradle() {
-        return !coralSensor.get();
-    }
-    /*
-
-    public Command intakeToOutputCommand() {
-        return this.run(this::startIndexer)
-                .until(this::hasCoral)
-                .andThen(this.run(this::startIndexer))
-                .until(() -> !hasCoral())
-                .andThen(this::stopIndexer);
-    }
-
-    public Command intakeAndHoldCommand(){
-        return this.run(this::startIndexer)
-        .until(this::hasCoral)
-        .andThen(this.run(this::holdIndexer));
-    }
-    */
-
     /**
      * Outputs coral into robot, assuming coral is being held right now
      * @return command
      */
-    public Command outputCommand(){
+    public Command outputCommand() {
         return this.run(this::startIndexer)
-        .until(() -> !hasCoral())
-        .andThen(this::stopIndexer);
+                .until(() -> !hasCoral())
+                .andThen(this::stopIndexer);
     }
 
     /**

--- a/src/main/java/com/team9470/subsystems/Superstructure.java
+++ b/src/main/java/com/team9470/subsystems/Superstructure.java
@@ -72,10 +72,10 @@ public class Superstructure extends SubsystemBase {
             autoPickupCommand = null;
         }
 
-        boolean cradle = indexer.isCoralInCradle();
-        boolean newlyDetected = cradle && pieceState == GamePieceState.EMPTY;
-        boolean cradleCleared = !cradle && pieceState == GamePieceState.CORAL_IN_CRADLE;
-        if (cradle)
+        boolean coralInCradle = indexer.hasCoral();
+        boolean newlyDetected = coralInCradle && pieceState == GamePieceState.EMPTY;
+        boolean cradleCleared = !coralInCradle && pieceState == GamePieceState.CORAL_IN_CRADLE;
+        if (coralInCradle)
             pieceState = GamePieceState.CORAL_IN_CRADLE;
         if(newlyDetected) {
             if (!arm.isHoldingItem() && autoPickupCommand == null) {
@@ -150,7 +150,7 @@ public class Superstructure extends SubsystemBase {
     }
 
     public Command waitForIntake() {
-        return new WaitUntilCommand(indexer::isCoralInCradle);
+        return new WaitUntilCommand(indexer::hasCoral);
     }
 
     public Command funnelOut() {
@@ -162,7 +162,7 @@ public class Superstructure extends SubsystemBase {
     }
 
     public boolean hasGamePiece() {
-        return arm.isHoldingItem() || indexer.isCoralInCradle();
+        return arm.isHoldingItem() || indexer.hasCoral();
     }
 
     public Elevator getElevator() {
@@ -183,10 +183,6 @@ public class Superstructure extends SubsystemBase {
 
     public Command scoreAndFunnel() {
         return indexer.outputCommand();
-    }
-
-    public boolean isCoralInCradle() {
-        return indexer.isCoralInCradle();
     }
 
     public boolean hasCoralInArm() {
@@ -255,7 +251,7 @@ public class Superstructure extends SubsystemBase {
                     } else {
                         arm.stopRollers();
                         arm.clearGamePieceFlags();
-                        pieceState = indexer.isCoralInCradle()
+                        pieceState = indexer.hasCoral()
                                 ? GamePieceState.CORAL_IN_CRADLE
                                 : GamePieceState.EMPTY;
                         activeMode = Mode.NONE;
@@ -295,7 +291,7 @@ public class Superstructure extends SubsystemBase {
                     } else {
                         arm.stopRollers();
                         arm.clearGamePieceFlags();
-                        pieceState = indexer.isCoralInCradle()
+                        pieceState = indexer.hasCoral()
                                 ? GamePieceState.CORAL_IN_CRADLE
                                 : GamePieceState.EMPTY;
                         activeMode = Mode.NONE;
@@ -386,7 +382,7 @@ public class Superstructure extends SubsystemBase {
                     arm.setHoldingCoral(false);
                     arm.stopRollers();
                     arm.clearGamePieceFlags();
-                    pieceState = indexer.isCoralInCradle()
+                    pieceState = indexer.hasCoral()
                             ? GamePieceState.CORAL_IN_CRADLE
                             : GamePieceState.EMPTY;
                     activeMode = Mode.NONE;
@@ -440,7 +436,7 @@ public class Superstructure extends SubsystemBase {
                     arm.setHoldingAlgae(false);
                     arm.stopRollers();
                     arm.clearGamePieceFlags();
-                    pieceState = indexer.isCoralInCradle()
+                    pieceState = indexer.hasCoral()
                             ? GamePieceState.CORAL_IN_CRADLE
                             : GamePieceState.EMPTY;
                     activeMode = Mode.NONE;
@@ -464,7 +460,7 @@ public class Superstructure extends SubsystemBase {
     public Command intakeCoralGround() {
         return Commands.sequence(
                 new ParallelDeadlineGroup(
-                        Commands.waitUntil(indexer::isCoralInCradle),
+                        Commands.waitUntil(indexer::hasCoral),
                         new ParallelCommandGroup(
                                 intake.goDownAndStartRollersCommand(),
                                 indexer.runCommand()


### PR DESCRIPTION
## Summary
- use the WPILib math Debouncer in rising-edge mode so the indexer clears coral detection immediately on release
- document the 0.1 s debounce constant as the rising-edge filter used for the cradle beam break

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68f4a328ec508324b1c39be6904162df