### PR TITLE
Handle empty vision target lists

### DIFF
--- a/src/main/java/com/team9470/subsystems/vision/VisionDevice.java
+++ b/src/main/java/com/team9470/subsystems/vision/VisionDevice.java
@@ -70,8 +70,8 @@ public class VisionDevice {
             Pose3d cameraPose = robotPose.plus(photonPoseEstimator.getRobotToCameraTransform());
             double timestamp = Utils.fpgaToCurrentTime(estimatedPose.timestampSeconds);
 
-            if (result.getTargets().size() < 2) {
-                if (result.getTargets().get(0).getPoseAmbiguity() > 0.2) return;
+            if (!hasUsableTargets(result.getTargets())) {
+                return;
             }
 
             double std_dev_multiplier = 1.0;
@@ -114,6 +114,18 @@ public class VisionDevice {
 
 
         }
+    }
+
+    static boolean hasUsableTargets(List<PhotonTrackedTarget> targets) {
+        if (targets.isEmpty()) {
+            return false;
+        }
+
+        if (targets.size() < 2) {
+            return targets.get(0).getPoseAmbiguity() <= 0.2;
+        }
+
+        return true;
     }
 
     private Pair<Double, Double> calculateDistanceStatistics(List<Pose3d> tagPoses, Pose3d cameraPose) {

--- a/src/test/java/com/team9470/subsystems/vision/VisionDeviceTest.java
+++ b/src/test/java/com/team9470/subsystems/vision/VisionDeviceTest.java
@@ -1,0 +1,17 @@
+package com.team9470.subsystems.vision;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class VisionDeviceTest {
+
+    @Test
+    void hasUsableTargetsHandlesEmptyList() {
+        assertDoesNotThrow(() -> VisionDevice.hasUsableTargets(Collections.emptyList()));
+        assertFalse(VisionDevice.hasUsableTargets(Collections.emptyList()));
+    }
+}


### PR DESCRIPTION
## Summary
- guard `VisionDevice` against empty target lists before evaluating ambiguity
- add a helper for target usability and cover the empty-list case with a unit test

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f4a971667c832480f1beb999101f5e