### PR TITLE
Adjust auto alignment controls

### DIFF
--- a/src/main/java/com/team9470/RobotContainer.java
+++ b/src/main/java/com/team9470/RobotContainer.java
@@ -133,12 +133,11 @@ public class RobotContainer {
                 .toggleOnTrue(superstructure.prepareLevel(Superstructure.Level.L4)
                         .finallyDo(superstructure::stow));
 
-//        xbox.leftBumper()
-//            .onTrue(autoScoring.autoScore(superstructure, AutoScoring.Side.LEFT));
-//
-//        xbox.rightBumper()
-//            .onTrue(autoScoring.autoScore(superstructure, AutoScoring.Side.RIGHT));
+        xbox.leftBumper()
+                .onTrue(autoScoring.autoAlign(superstructure, AutoScoring.Side.LEFT));
 
+        xbox.leftTrigger()
+                .onTrue(autoScoring.autoAlign(superstructure, AutoScoring.Side.RIGHT));
 
         xbox.rightBumper()
                 .whileTrue(

--- a/src/main/java/com/team9470/commands/AutoScoring.java
+++ b/src/main/java/com/team9470/commands/AutoScoring.java
@@ -44,6 +44,27 @@ public class AutoScoring {
         }, Set.of(drivetrain, superstructure));
     }
 
+    public Command autoAlign(Superstructure superstructure) {
+        return Commands.defer(() -> {
+            CoralObjective objective = new CoralObjective(findClosestBranch(), superstructure.currentLevel);
+            coralObjective = objective;
+            SmartDashboard.putNumber("AutoScoring/Branch ID", objective.branchId());
+            SmartDashboard.putString("AutoScoring/Level", objective.level().name());
+            return createAutoAlignCommand(objective, drivetrain, false);
+        }, Set.of(drivetrain));
+    }
+
+    public Command autoAlign(Superstructure superstructure, Side side) {
+        return Commands.defer(() -> {
+            int branchId = findClosestBranch(side);
+            CoralObjective objective = new CoralObjective(branchId, superstructure.currentLevel);
+            coralObjective = objective;
+            SmartDashboard.putNumber("AutoScoring/Branch ID", branchId);
+            SmartDashboard.putString("AutoScoring/Level", objective.level().name());
+            return createAutoAlignCommand(objective, drivetrain, false);
+        }, Set.of(drivetrain));
+    }
+
     public void updateClosestReefPos() {
         setBranch(findClosestBranch());
     }
@@ -147,6 +168,12 @@ public class AutoScoring {
         Command driveAndPrepare = Commands.deadline(drive, prepare);
 
         return driveAndPrepare.andThen(superstructure.coralScore(objective.level()));
+    }
+
+    private static Command createAutoAlignCommand(CoralObjective objective, Swerve drivetrain, boolean straight) {
+        return straight
+                ? new DriveToPose(objective::getScoringPose, drivetrain, true)
+                : new DriveToPose(objective::getScoringPose, drivetrain);
     }
 
     public enum Side {


### PR DESCRIPTION
## Summary
- add auto-alignment commands that only drive the drivetrain without preparing or scoring
- bind the left bumper and left trigger to left/right auto-align while keeping scoring on the right bumper

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68f554a3c0b88324a2723b83002752a6