### PR TITLE
Normalize sweep waypoint drive speed

### DIFF
--- a/src/main/java/com/team9470/RobotContainer.java
+++ b/src/main/java/com/team9470/RobotContainer.java
@@ -59,6 +59,8 @@ public class RobotContainer {
         autoChooser.addRoutine("5CBA", autos::getFiveCoralBottomAutoAlign);
         autoChooser.addRoutine("5CBA-NW", autos::getFiveCoralBottomAutoAlignNoWait);
         autoChooser.addRoutine("5CTA-NW", autos::getFiveCoralTopAutoAlignNoWait);
+        autoChooser.addRoutine("4CTS", autos::getFourCoralTopAutoSweep);
+        autoChooser.addRoutine("4CBS", autos::getFourCoralBottomAutoSweep);
         autoChooser.select("2C Test");
         SmartDashboard.putData("AutoChooser", autoChooser);
         SmartDashboard.putData("Mechanism", mech);

--- a/src/main/java/com/team9470/commands/Autos.java
+++ b/src/main/java/com/team9470/commands/Autos.java
@@ -80,31 +80,35 @@ public class Autos extends SubsystemBase{
         return AllianceFlipUtil.apply(new Pose2d(1.8302104473114014, 2.1849470138549805, Rotation2d.fromDegrees(-54)));
     }
 
-        /**
-         * Creates a command that performs a sweeping motion through the specified waypoints.
-         * The robot will move through each position in sequence, maintaining the specified heading at each waypoint.
-         *
-         * @return Command that executes the sweeping motion
-         */
-        public Command getSweepMotionCommand(boolean top) {
+    /**
+     * Creates a command that performs a sweeping motion through the specified waypoints.
+     * The robot will move through each position in sequence, maintaining the specified heading at each waypoint.
+     *
+     * @return Command that executes the sweeping motion
+     */
+    public Command getSweepMotionCommand(boolean top) {
+        return getSweepMotionCommand(top, false);
+    }
+
+    public Command getSweepMotionCommand(boolean top, boolean useDriveToPose) {
         // Define different waypoints for top vs bottom source
         Pose2d[] waypoints;
 
         if (top) {
             waypoints = new Pose2d[]{
-                new Pose2d(2.8092904090881348, 7.4921770095825195, Rotation2d.fromDegrees(0)),
-                new Pose2d(2.0143749713897705, 7.4921770095825195, Rotation2d.fromDegrees(19.5)),
-                new Pose2d(1.2194594144821167, 7.164858818054199, Rotation2d.fromDegrees(36)),
-                new Pose2d(0.728482186794281, 6.627121925354004, Rotation2d.fromDegrees(55)),
-                new Pose2d(0.5648230910301208, 5.972485542297363, Rotation2d.fromDegrees(90))
+                    new Pose2d(2.8092904090881348, 7.4921770095825195, Rotation2d.fromDegrees(0)),
+                    new Pose2d(2.0143749713897705, 7.4921770095825195, Rotation2d.fromDegrees(19.5)),
+                    new Pose2d(1.2194594144821167, 7.164858818054199, Rotation2d.fromDegrees(36)),
+                    new Pose2d(0.728482186794281, 6.627121925354004, Rotation2d.fromDegrees(55)),
+                    new Pose2d(0.5648230910301208, 5.972485542297363, Rotation2d.fromDegrees(90))
             };
         } else {
             waypoints = new Pose2d[]{
-                new Pose2d(2.8092904090881348, 0.7078229904174805, Rotation2d.fromDegrees(0)),
-                new Pose2d(2.0143749713897705, 0.7078229904174805, Rotation2d.fromDegrees(-19.5)),
-                new Pose2d(1.2194594144821167, 1.0351411819458008, Rotation2d.fromDegrees(-36)),
-                new Pose2d(0.728482186794281, 1.572878074645996, Rotation2d.fromDegrees(-55)),
-                new Pose2d(0.5648230910301208, 2.227514457702637, Rotation2d.fromDegrees(-90))
+                    new Pose2d(2.8092904090881348, 0.7078229904174805, Rotation2d.fromDegrees(0)),
+                    new Pose2d(2.0143749713897705, 0.7078229904174805, Rotation2d.fromDegrees(-19.5)),
+                    new Pose2d(1.2194594144821167, 1.0351411819458008, Rotation2d.fromDegrees(-36)),
+                    new Pose2d(0.728482186794281, 1.572878074645996, Rotation2d.fromDegrees(-55)),
+                    new Pose2d(0.5648230910301208, 2.227514457702637, Rotation2d.fromDegrees(-90))
             };
         }
 
@@ -113,15 +117,16 @@ public class Autos extends SubsystemBase{
             waypoints[i] = AllianceFlipUtil.apply(waypoints[i]);
         }
 
-        // Create a sequence of DriveToPose commands for each waypoint
-        Command[] driveCommands = new Command[waypoints.length];
-        for (int i = 0; i < waypoints.length; i++) {
-            final int index = i; // Capture for lambda
-            driveCommands[i] = new DriveToPose(() -> waypoints[index], swerve, true, 0.5);
+        if (useDriveToPose) {
+            Command[] driveCommands = new Command[waypoints.length];
+            for (int i = 0; i < waypoints.length; i++) {
+                final int index = i; // Capture for lambda
+                driveCommands[i] = new DriveToPose(() -> waypoints[index], swerve, true, 0.5);
+            }
+            return Commands.sequence(driveCommands);
         }
 
-        // Return a sequential command that moves through all waypoints
-        return Commands.sequence(driveCommands);
+        return new DriveThroughWaypoints(swerve, waypoints, true, 0.5);
     }
 
 

--- a/src/main/java/com/team9470/commands/DriveThroughWaypoints.java
+++ b/src/main/java/com/team9470/commands/DriveThroughWaypoints.java
@@ -1,0 +1,135 @@
+package com.team9470.commands;
+
+import com.team9470.TunerConstants;
+import com.team9470.subsystems.Swerve;
+import com.team9470.util.LogUtil;
+import edu.wpi.first.math.controller.ProfiledPIDController;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.math.trajectory.TrapezoidProfile;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.Command;
+
+/**
+ * Drives the robot through a series of {@link Pose2d} waypoints without fully stopping at each point.
+ * The command advances to the next waypoint once the robot is within a configurable handoff radius,
+ * allowing for a continuous sweeping motion while still leveraging the {@link DriveToPose} alignment
+ * logic for individual targets.
+ */
+public class DriveThroughWaypoints extends Command {
+    private static final double DEFAULT_HANDOFF_RADIUS_METERS = 0.35;
+
+    private final Swerve drivetrain;
+    private final Pose2d[] waypoints;
+    private final boolean noInterpolate;
+    private final double tolerance;
+    private final double handoffRadius;
+
+    private int currentIndex = 0;
+    private Pose2d currentTarget;
+
+    private final TrapezoidProfile.Constraints translationConstraints =
+            new TrapezoidProfile.Constraints(TunerConstants.maxVelocity, TunerConstants.maxAcceleration);
+    private final TrapezoidProfile.Constraints rotationConstraints =
+            new TrapezoidProfile.Constraints(TunerConstants.maxAngularVelocity, TunerConstants.maxAngularAcceleration);
+
+    private final ProfiledPIDController pidControllerX = new ProfiledPIDController(5, 0, 0, translationConstraints);
+    private final ProfiledPIDController pidControllerY = new ProfiledPIDController(5, 0, 0, translationConstraints);
+    private final ProfiledPIDController pidControllerOmega = new ProfiledPIDController(7, 0, 0, rotationConstraints);
+
+    public DriveThroughWaypoints(Swerve drivetrain, Pose2d[] waypoints, boolean noInterpolate, double tolerance) {
+        this(drivetrain, waypoints, noInterpolate, tolerance, DEFAULT_HANDOFF_RADIUS_METERS);
+    }
+
+    public DriveThroughWaypoints(
+            Swerve drivetrain, Pose2d[] waypoints, boolean noInterpolate, double tolerance, double handoffRadius) {
+        this.drivetrain = drivetrain;
+        this.waypoints = waypoints;
+        this.noInterpolate = noInterpolate;
+        this.tolerance = tolerance;
+        this.handoffRadius = handoffRadius;
+
+        pidControllerOmega.enableContinuousInput(-Math.PI, Math.PI);
+
+        addRequirements(drivetrain);
+    }
+
+    @Override
+    public void initialize() {
+        currentIndex = 0;
+        currentTarget = waypoints.length > 0 ? waypoints[0] : null;
+
+        Pose2d currentPose = drivetrain.getPose();
+        pidControllerX.reset(currentPose.getX());
+        pidControllerY.reset(currentPose.getY());
+        pidControllerOmega.reset(currentPose.getRotation().getRadians());
+    }
+
+    @Override
+    public void execute() {
+        if (currentTarget == null) {
+            return;
+        }
+
+        Pose2d robotPose = drivetrain.getPose();
+        Pose2d driveTarget = noInterpolate ? currentTarget : DriveToPose.getDriveTarget(robotPose, currentTarget);
+
+        LogUtil.recordPose2d("DriveThroughWaypoints/CurrentTarget", currentTarget);
+        LogUtil.recordPose2d("DriveThroughWaypoints/DriveTarget", driveTarget);
+
+        double xSpeed = pidControllerX.calculate(robotPose.getX(), driveTarget.getX());
+        double ySpeed = pidControllerY.calculate(robotPose.getY(), driveTarget.getY());
+        double thetaSpeed = pidControllerOmega.calculate(
+                robotPose.getRotation().getRadians(), driveTarget.getRotation().getRadians());
+
+        double translationMagnitude = Math.hypot(xSpeed, ySpeed);
+        if (translationMagnitude > 1e-5) {
+            boolean atLastWaypoint = currentIndex >= waypoints.length - 1;
+            double desiredMagnitude = atLastWaypoint
+                    ? Math.min(translationMagnitude, translationConstraints.maxVelocity)
+                    : translationConstraints.maxVelocity;
+
+            double scale = desiredMagnitude / translationMagnitude;
+            xSpeed *= scale;
+            ySpeed *= scale;
+        } else {
+            xSpeed = 0;
+            ySpeed = 0;
+        }
+
+        drivetrain.setChassisSpeeds(
+                ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, thetaSpeed, robotPose.getRotation()));
+
+        if (currentIndex < waypoints.length - 1
+                && robotPose.getTranslation().getDistance(currentTarget.getTranslation()) <= handoffRadius) {
+            currentIndex++;
+            currentTarget = waypoints[currentIndex];
+        }
+    }
+
+    @Override
+    public boolean isFinished() {
+        if (currentTarget == null) {
+            return true;
+        }
+
+        Pose2d robotPose = drivetrain.getPose();
+        SmartDashboard.putNumber(
+                "DriveThroughWaypoints/TranslationError",
+                robotPose.getTranslation().getDistance(currentTarget.getTranslation()));
+        SmartDashboard.putNumber(
+                "DriveThroughWaypoints/HeadingError",
+                Math.abs(robotPose.getRotation().minus(currentTarget.getRotation()).getDegrees()));
+
+        boolean atLastWaypoint = currentIndex >= waypoints.length - 1;
+        return atLastWaypoint
+                && robotPose.getTranslation().getDistance(currentTarget.getTranslation()) <= 0.01 * tolerance
+                && Math.abs(robotPose.getRotation().minus(currentTarget.getRotation()).getDegrees()) <= 1 * tolerance;
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        drivetrain.setChassisSpeeds(new ChassisSpeeds(0, 0, 0));
+    }
+}
+

--- a/src/main/java/com/team9470/commands/DriveToPose.java
+++ b/src/main/java/com/team9470/commands/DriveToPose.java
@@ -105,7 +105,7 @@ public class DriveToPose extends Command {
         drivetrain.setChassisSpeeds(new ChassisSpeeds(0, 0, 0));
     }
 
-    private static Pose2d getDriveTarget(Pose2d robot, Pose2d goal) {
+    public static Pose2d getDriveTarget(Pose2d robot, Pose2d goal) {
         Translation2d offset = robot.relativeTo(goal).getTranslation();
         double yDistance = Math.abs(offset.getY());
         double xDistance = Math.abs(offset.getX());


### PR DESCRIPTION
## Summary
- rescale the sweep waypoint controller outputs so intermediate segments run at a constant cruise speed
- keep the PID-based slowdown for the terminal waypoint to preserve precise docking behavior

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68fc6dfee4448324956e96175c5fb934